### PR TITLE
Changing function name for failure report

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -27,7 +27,7 @@ smoke_form() {
     FORMDATA="$2"
 
     if [[ ! -f "$FORMDATA" ]]; then
-        _smoke_print_fail "No formdata file"
+        _smoke_print_failure "No formdata file"
         _smoke_cleanup
         exit 1
     fi


### PR DESCRIPTION
`./tests_smoke/smoke.sh: line 30: _smoke_print_fail: command not found`

To recreate:
Specify a file that doesn't exist using `smoke_form_ok`