### PR TITLE
Add debug function and allow testing redirect codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,17 @@ smoke_response_body    # raw body (html/json/...)
 smoke_response_headers # list of headers
 ```
 
+### Debugging
+
+In order to debug your requests, call `smoke_debug` before calling `smoke_url`:
+
+```bash
+smoke_debug
+smoke_url_ok "http://google.com"
+```
+
+You can turn off debugging by calling `smoke_no_debug`
+
 Advanced example
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ The minimal smoke test will check if a URL returns with a 200 response code:
 smoke_url_ok "http://google.com"
 ```
 
+It is also possible to check for other response codes explicitly:
+
+```bash
+smoke_url "http://google.com/doesnotexist"
+smoke_assert_code 404
+```
+
+### GET a URL and check for redirects
+
+In order to check for redirects, you must call `smoke_no_follow` before calling `smoke_url`:
+
+```bash
+smoke_no_follow
+smoke_url "http://google.com"
+smoke_assert_code 302
+```
+
+You can follow redirects again by calling `smoke_follow`
+
 ### POST a URL and check the response code
 
 A more advanced smoke test will POST data to a URL. Such a test can be used to

--- a/smoke.sh
+++ b/smoke.sh
@@ -7,6 +7,7 @@ SMOKE_CURL_CODE="$SMOKE_TMP_DIR/smoke_curl_code"
 SMOKE_CURL_HEADERS="$SMOKE_TMP_DIR/smoke_curl_headers"
 SMOKE_CURL_BODY="$SMOKE_TMP_DIR/smoke_curl_body"
 SMOKE_CURL_COOKIE_JAR="$SMOKE_TMP_DIR/smoke_curl_cookie_jar"
+SMOKE_CURL_FOLLOW="--location"
 
 SMOKE_CSRF_TOKEN=""
 SMOKE_CSRF_FORM_DATA="$SMOKE_TMP_DIR/smoke_csrf_form_data"
@@ -20,6 +21,15 @@ SMOKE_HEADER_HOST=""
 
 smoke_csrf() {
     SMOKE_CSRF_TOKEN="$1"
+}
+
+
+smoke_follow() {
+    SMOKE_CURL_FOLLOW="--location"
+}
+
+smoke_no_follow() {
+    SMOKE_CURL_FOLLOW=""
 }
 
 smoke_form() {
@@ -173,7 +183,7 @@ _smoke_success() {
 
 ## Curl helpers
 _curl() {
-  local opt=(--cookie $SMOKE_CURL_COOKIE_JAR --cookie-jar $SMOKE_CURL_COOKIE_JAR --location --dump-header $SMOKE_CURL_HEADERS --silent)
+  local opt=(--cookie $SMOKE_CURL_COOKIE_JAR --cookie-jar $SMOKE_CURL_COOKIE_JAR $SMOKE_CURL_FOLLOW --dump-header $SMOKE_CURL_HEADERS --silent)
   if [[ -n "$SMOKE_HEADER_HOST" ]]
   then
     opt+=(-H "Host: $SMOKE_HEADER_HOST")

--- a/smoke.sh
+++ b/smoke.sh
@@ -8,6 +8,7 @@ SMOKE_CURL_HEADERS="$SMOKE_TMP_DIR/smoke_curl_headers"
 SMOKE_CURL_BODY="$SMOKE_TMP_DIR/smoke_curl_body"
 SMOKE_CURL_COOKIE_JAR="$SMOKE_TMP_DIR/smoke_curl_cookie_jar"
 SMOKE_CURL_FOLLOW="--location"
+SMOKE_CURL_VERBOSE="--silent"
 
 SMOKE_CSRF_TOKEN=""
 SMOKE_CSRF_FORM_DATA="$SMOKE_TMP_DIR/smoke_csrf_form_data"
@@ -23,6 +24,13 @@ smoke_csrf() {
     SMOKE_CSRF_TOKEN="$1"
 }
 
+smoke_debug() {
+    SMOKE_CURL_VERBOSE="--verbose"
+}
+
+smoke_no_debug() {
+    SMOKE_CURL_VERBOSE="--silent"
+}
 
 smoke_follow() {
     SMOKE_CURL_FOLLOW="--location"
@@ -183,7 +191,7 @@ _smoke_success() {
 
 ## Curl helpers
 _curl() {
-  local opt=(--cookie $SMOKE_CURL_COOKIE_JAR --cookie-jar $SMOKE_CURL_COOKIE_JAR $SMOKE_CURL_FOLLOW --dump-header $SMOKE_CURL_HEADERS --silent)
+  local opt=(--cookie $SMOKE_CURL_COOKIE_JAR --cookie-jar $SMOKE_CURL_COOKIE_JAR $SMOKE_CURL_FOLLOW --dump-header $SMOKE_CURL_HEADERS $SMOKE_CURL_VERBOSE)
   if [[ -n "$SMOKE_HEADER_HOST" ]]
   then
     opt+=(-H "Host: $SMOKE_HEADER_HOST")


### PR DESCRIPTION
I had a test case where I needed to ensure some paths were being redirected by the server, so I added functions that enable/disable the curl's follow redirect option.

I also find it interesting sometimes to have a more verbose output for debugging purposes.