### PR TITLE
Change to pre-increment, to avoid triggering an error with set -e

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -149,8 +149,8 @@ _smoke_cleanup() {
 
 _smoke_fail() {
     REASON="$1"
-    (( SMOKE_TESTS_FAILED++ ))
-    (( SMOKE_TESTS_RUN++ ))
+    (( ++SMOKE_TESTS_FAILED ))
+    (( ++SMOKE_TESTS_RUN ))
     _smoke_print_failure "$REASON"
 }
 
@@ -168,7 +168,7 @@ _smoke_prepare_formdata() {
 _smoke_success() {
     REASON="$1"
     _smoke_print_success "$REASON"
-    (( SMOKE_TESTS_RUN++ ))
+    (( ++SMOKE_TESTS_RUN ))
 }
 
 ## Curl helpers


### PR DESCRIPTION
When using smoke.sh with `set -e` it will error after the first, when it's trying to increment the counter.
Arithmetic Expansion will return 1 when the expression returns 0, otherwise it'll return 0. So by doing a pre-increment, we avoid the expression to ever return 0.
See [this stackexchange post](https://unix.stackexchange.com/questions/32250/why-does-a-0-let-a-return-exit-code-1/32251#32251) for more details.