### PR TITLE
Add support for setting additional request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,17 @@ To un-override, set it empty:
 smoke_host ""
 ```
 
+### Overriding request headers
+
+It's possible to set additional request headers, like `X-Forwarded-Proto` for local tests.
+
+```
+smoke_header "X-Forwarded-Host: orginal.example.org"
+smoke_header "X-Forwarded-Proto: https"
+```
+
+Existing custom headers can be unset with `remove_smoke_headers`.
+
 ### CSRF tokens
 
 Web applications that are protected with CSRF tokens will need to extract a
@@ -235,4 +246,5 @@ API
 |`smoke_url_ok <url>`             | GET a url and check for a `2xx` response code        |
 |`smoke_url_prefix <prefix>`      | set the prefix to use for every url (e.g. domain)    |
 |`smoke_host <host>`              | set the host header to use                           |
+|`smoke_header <header>`          | set additional request header                        |
 |`smoke_tcp_ok <host> <port>`     | open a tcp connection and check for a `Connected` response |

--- a/smoke.sh
+++ b/smoke.sh
@@ -14,7 +14,7 @@ SMOKE_CSRF_FORM_DATA="$SMOKE_TMP_DIR/smoke_csrf_form_data"
 SMOKE_TESTS_FAILED=0
 SMOKE_TESTS_RUN=0
 SMOKE_URL_PREFIX=""
-SMOKE_HEADER_HOST=""
+SMOKE_HEADERS=()
 
 ## "Public API"
 
@@ -86,8 +86,16 @@ smoke_url_prefix() {
     SMOKE_URL_PREFIX="$1"
 }
 
+smoke_header() {
+    SMOKE_HEADERS+=("$1")
+}
+
 smoke_host() {
-    SMOKE_HEADER_HOST="$1"
+    smoke_header "Host: $1"
+}
+
+remove_smoke_headers() {
+    unset SMOKE_HEADERS
 }
 
 ## Assertions
@@ -174,10 +182,14 @@ _smoke_success() {
 ## Curl helpers
 _curl() {
   local opt=(--cookie $SMOKE_CURL_COOKIE_JAR --cookie-jar $SMOKE_CURL_COOKIE_JAR --location --dump-header $SMOKE_CURL_HEADERS --silent)
-  if [[ -n "$SMOKE_HEADER_HOST" ]]
-  then
-    opt+=(-H "Host: $SMOKE_HEADER_HOST")
+
+  if (( ${#SMOKE_HEADERS[@]} )); then
+    for header in "${SMOKE_HEADERS[@]}"
+    do
+        opt+=(-H "$header")
+    done
   fi
+
   curl "${opt[@]}" "$@" > $SMOKE_CURL_BODY
 }
 


### PR DESCRIPTION
In local tests it's sometimes necessary to set additional headers, like
`X-Forwarded-Proto` if TLS termination happens outside the actual
application in production.

This change is based on Olga Peshkova's work: https://github.com/airinp/smoke.sh/commit/52b7f52a7a9b54f25dca888a235248f4e8009c98

@asm89 @matthiasr @airinp