### PR TITLE
Add insensive HTTP header check per RFC 2616

### DIFF
--- a/smoke.sh
+++ b/smoke.sh
@@ -136,7 +136,7 @@ smoke_assert_body() {
 smoke_assert_headers() {
     STRING="$1"
 
-    smoke_response_headers | grep --quiet "$STRING"
+    smoke_response_headers | grep --quiet -i "$STRING"
 
     if [[ $? -eq 0 ]]; then
         _smoke_success "Headers contain \"$STRING\""


### PR DESCRIPTION
Per RFC 2616: header names are case insensitive, so the check:

`smoke_assert_headers "content-type: application/json; charset=utf-8"`

**should succeed** when server returns the header names in any of these ways:
`Content-Type: application/json; charset=utf-8`
`content-type: application/json; charset=utf-8`
`CoNTEnT-type: application/json; charset=utf-8`
etc...

Room for improvement:
The current implementation and the proposed fix is not splitting the header from the value.
So header value should be checked for differences in upper/lower case.




